### PR TITLE
Melhorar organização das tabelas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,48 @@ Se quiseres contribuir, corrigir algo, ou até recomendar melhorias, cria um pul
 
 ## APIs
 
-| API         |  Info | Categoria | Spec | Docs |
-| ----------- | ----- | :-------: | :--: | :--: |
-| [Vost Covid](https://covid19-api.vost.pt/) | Dados DGS COVID-19 | Saúde | [✅](https://covid19-api.vost.pt/swagger.json) | ❌
-| [Dados Gov](https://dados.gov.pt/pt/docapi/) | Dados abertos em Portugal | Governo | [✅](https://dados.gov.pt/api/1/swagger.json) | [✅](https://dados.gov.pt/pt/docapi/)
-| [IPMA](https://api.ipma.pt/) | Dados meteorológicos e oceanográficos | Meteorologia | ❌ | [✅](https://api.ipma.pt/)
-| [Metro de Lisboa](https://api.metrolisboa.pt/store/apis/info?name=EstadoServicoML&version=1.0.1&provider=admin) | Conjunto de APIs disponibilizadas pelo ML | Meteorologia | [✅](https://api.metrolisboa.pt/store/api-docs/admin/EstadoServicoML/1.0.1?gwType=undefined&gwName=undefined) | [✅](https://api.metrolisboa.pt/store/apis/info?name=EstadoServicoML&version=1.0.1&provider=admin#tab2)
-| [TransporLis](https://www.transporlis.pt/Default.aspx?tabid=258&language=pt-PT) | Dados abertos dos transportes públicos de Lisboa | Transportes | ⁉️ | ⁉️
-| [NIF](https://www.nif.pt/api/) | Validação programatica de NIF | Governo | ❌ | ❌
+### Governo
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
+| [Dados Gov](https://dados.gov.pt/pt/docapi/) | Dados abertos em Portugal | [✅](https://dados.gov.pt/api/1/swagger.json) | [✅](https://dados.gov.pt/pt/docapi/)
+| [GEO PT API](https://github.com/jfoclpf/geoptapi) | Regiões de Portugal | ❌ | [✅](https://github.com/jfoclpf/geoptapi)
+| [INE](https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_api&INST=322751522&xlang=pt) | Base de dados de difusão do INE | ❌ | [✅](https://www.ine.pt/ngt_server/attachfileu.jsp?look_parentBoui=322762582&att_display=n&att_download=y)
+| [Lisboa Aberta](http://lisboaaberta.cm-lisboa.pt/index.php/pt/desenvolvedores) | Dados abertos de Lisboa | ⁉️ | ⁉️
+| [NIF](https://www.nif.pt/api/) | Validação programatica de NIF | ❌ | ❌
+| [Turismo de Portugal](https://dadosabertos.turismodeportugal.pt/) | Dados sobre informação turística | ⁉️ | ⁉️
+
+### Saúde
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
+| [Vost Covid](https://covid19-api.vost.pt/) | Dados DGS COVID-19 | [✅](https://covid19-api.vost.pt/swagger.json) | ❌
+
+### Meteorologia
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
+| [IPMA](https://api.ipma.pt/) | Dados meteorológicos e oceanográficos | ❌ | [✅](https://api.ipma.pt/)
+
+### Transportes
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
+| [CP](https://github.com/juliuste/comboios) | Cliente em JS para a API da CP | [✅]() | [✅](https://github.com/juliuste/comboios)
+| [EMEL](https://emel.city-platform.com/opendata/) | Dados abertos da EMEL | [✅](https://emel.city-platform.com/opendata/) | ❌
+| [Metro de Lisboa](https://api.metrolisboa.pt/store/apis/info?name=EstadoServicoML&version=1.0.1&provider=admin) | Conjunto de APIs disponibilizadas pelo ML | [✅](https://api.metrolisboa.pt/store/api-docs/admin/EstadoServicoML/1.0.1?gwType=undefined&gwName=undefined) | [✅](https://api.metrolisboa.pt/store/apis/info?name=EstadoServicoML&version=1.0.1&provider=admin#tab2)
+| [TransporLis](https://www.transporlis.pt/Default.aspx?tabid=258&language=pt-PT) | Dados abertos dos transportes públicos de Lisboa | ⁉️ | ⁉️
+
+### Media
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
+| [Observador](https://observador.pt/wp-json/) | Dados do Observador | ❌ | ❌
+| [PT-NEWS-EXTRACTOR](https://github.com/spamz23/PT-NEWS_EXTRACTOR) | Notícias de jornais | [✅](https://pt-news-extractor.herokuapp.com/#operation/cm_url_search_create) | ❌
+| [Público](https://www.publico.pt/api/list/ultimas) | Dados do Público | ❌ | ❌
+
+### Outros
+
+| API         |  Info | Spec | Docs |
+| ----------- | ----- | :--: | :--: |
 | [arquivo.pt](https://arquivo.pt/) | Acesso a conteúdo histórico da Web | Outros | ❌ | [✅](https://github.com/arquivo/pwa-technologies/wiki/Arquivo.pt-API)
-| [Observador](https://observador.pt/wp-json/) | Dados do Observador | Media | ❌ | ❌
-| [Público](https://www.publico.pt/api/list/ultimas) | Dados do Público | Media | ❌ | ❌
-| [INE](https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_api&INST=322751522&xlang=pt) | Base de dados de difusão do INE | Governo | ❌ | [✅](https://www.ine.pt/ngt_server/attachfileu.jsp?look_parentBoui=322762582&att_display=n&att_download=y)
-| [Lisboa Aberta](http://lisboaaberta.cm-lisboa.pt/index.php/pt/desenvolvedores) | Dados abertos de Lisboa | Governo | ⁉️ | ⁉️
-| [PT-NEWS-EXTRACTOR](https://github.com/spamz23/PT-NEWS_EXTRACTOR) | Notícias de jornais | Media | [✅](https://pt-news-extractor.herokuapp.com/#operation/cm_url_search_create) | ❌
-| [EMEL](https://emel.city-platform.com/opendata/) | Dados abertos da EMEL | Transportes | [✅](https://emel.city-platform.com/opendata/) | ❌
-| [Turismo de Portugal](https://dadosabertos.turismodeportugal.pt/) | Dados sobre informação turística | Governo | ⁉️ | ⁉️
-| [GEO PT API](https://github.com/jfoclpf/geoptapi) | Regiões de Portugal | Governo | ❌ | [✅](https://github.com/jfoclpf/geoptapi)
-| [CP](https://github.com/juliuste/comboios) | Cliente em JS para a API da CP | Transportes | [✅]() | [✅](https://github.com/juliuste/comboios)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Se quiseres contribuir, corrigir algo, ou até recomendar melhorias, cria um pul
 - Spec (link, com ícone, para a spec da API)
 - Docs (link, com ícone, para documentação da API)
 
+### Como posso começar?
+
+1. Faz fork do projeto (<https://github.com/devpt-org/public-api-portugal/fork>)
+2. Cria uma branch para a tua feature (`git checkout -b add/bank-public-api`)
+3. Faz commit das tuas alterações (`git commit -am 'Add some bank public api'`)
+4. Faz push da tua branch para master (`git push origin add/bank-public-api`)
+5. Cria um novo Pull Request
+
 ## Conteúdos
 - [Governo](#governo)
 - [Saúde](#saúde)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Se quiseres contribuir, corrigir algo, ou até recomendar melhorias, cria um pul
 - Spec (link, com ícone, para a spec da API)
 - Docs (link, com ícone, para documentação da API)
 
+## Conteúdos
+- [Governo](#governo)
+- [Saúde](#saúde)
+- [Meteorologia](#meteorologia)
+- [Transportes](#transportes)
+- [Media](#media)
+- [Outros](#outros)
+
 ## APIs
 
 ### Governo


### PR DESCRIPTION
Gosto mais do formato de tabela atual, no entanto a informação parece-me um pouco dispersa e complicada de rapidamente perceber o que pertence a cada categoria (que ainda é algo importante quando vês um diretório de algo).

Sugiro uma categoria que anteceda cada tabela, e os itens da mesma ordenadas por ordem alfabética (assim evitas ter de saber como ordenar, e para quem procura informação sabe de antemão o que espera e como procurar).

Numa side-note, o que achas que se adicionar instruções com os comandos como temos por exemplo no https://github.com/devpt-org/devpt-org.github.io#como-contribuir? Para incentivar alguém que não saiba exatamente o que fazer, possa seguir instruções linha-a-linha.

Fico a aguardar feedback!